### PR TITLE
chore: update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 
 flaskapp/__pycache__
 flaskapp/flaskapp.wsgi
+
+*.pyc


### PR DESCRIPTION
This is so that the server doesn't have to track compiled files (this
may cause problems in future merges)