### PR TITLE
Improve testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,17 @@ flask run
 
 ## Running the tests
 
-TODO
+To run the tests, execute the following command on your terminal:
+
+```
+coverage run --source flaskapp flaskapp/tests.py
+```
+
+If you are using a virtual env, you can use this command:
+
+```
+coverage run --source flaskapp --omit '*/venv/*' flaskapp/tests.py
+```
 
 ## Deployment
 

--- a/flaskapp/flaskapp.py
+++ b/flaskapp/flaskapp.py
@@ -76,18 +76,6 @@ def post():                                         # pragma: no cover
     else:
         return 'invalid request'
 
-#Handle shutdown
-@app.route('/shutdown', methods=['POST'])
-def shutdown():
-    shutdown_server()
-    return 'Server shutting down...'
-
-def shutdown_server():
-    func = request.environ.get('werkzeug.server.shutdown')
-    if func is None:
-        raise RuntimeError('Not running with the Werkzeug Server')
-    func()
-
 
 #Used if there is an error in the application.
 @app.errorhandler(Exception)

--- a/flaskapp/tests.py
+++ b/flaskapp/tests.py
@@ -12,17 +12,11 @@ from multiprocessing import Process
 import time
 
 class FirstTest(LiveServerTestCase):
-
-    #Local url
-    url = 'http://127.0.0.1:5000/'
-
     #Initialise testing app
     def create_app(self):
-        app = Flask(__name__)
-        #app.config['TESTING'] = True
-        # Default port is 5000
+        app = flaskapp.app
+        app.config['TESTING'] = True
         app.config['LIVESERVER_PORT'] = 8943
-        # Default timeout is 5 seconds
         app.config['LIVESERVER_TIMEOUT'] = 10
         return app
 
@@ -31,7 +25,8 @@ class FirstTest(LiveServerTestCase):
 
     ###This must be first
     def test_shutdown_text_outputted(self):
-        r = requests.post(url = self.url + 'shutdown', data = {})
+        url = self.get_server_url() + '/shutdown'
+        r = requests.post(url = url, data = {})
         self.assertEqual(r.text, 'Server shutting down...')
 
     def test_shutdown_error_outputted(self):
@@ -40,15 +35,15 @@ class FirstTest(LiveServerTestCase):
             print 'Errored as expected: '+r.text
 
     def test_server_is_up_and_running(self):
-        print self.get_server_url()
-        response = urllib2.urlopen(self.url)
+        url = self.get_server_url() + '/'
+        response = urllib2.urlopen(self.get_server_url())
         self.assertEqual(response.code, 200)
         print 'Server is up and running'
 
     def test_post_vals_works_with_correct_vals(self):
         data = {'onOff':1, 'turnAngle':41.0}
-        urlPost = self.url + 'post'
-        r = requests.post(url = urlPost, data = data)
+        url = self.get_server_url() + '/post'
+        r = requests.post(url = url, data = data)
         retData = eval(str(r.text))
         self.assertEqual(data['turnAngle'], retData['turnAngle'])
         self.assertEqual(data['onOff'], retData['onOff'])
@@ -56,15 +51,15 @@ class FirstTest(LiveServerTestCase):
 
     def test_post_vals_fails_with_invalid_turnangle(self):
         data = {'onOff':1, 'turnAngle':181.0}
-        urlPost = self.url + 'post'
-        r = requests.post(url = urlPost, data = data)
+        url = self.get_server_url() + '/post'
+        r = requests.post(url = url, data = data)
         self.assertEqual('invalid request', r.text)
         print 'Failed as expected: '+r.text
 
     def test_post_vals_fails_with_invalid_onoff(self):
         data = {'onOff':2, 'turnAngle':41.0}
-        urlPost = self.url + 'post'
-        r = requests.post(url = urlPost, data = data)
+        url = self.get_server_url() + '/post'
+        r = requests.post(url = url, data = data)
         self.assertEqual('invalid request', r.text)
         print 'Failed as expected: '+r.text
 
@@ -110,7 +105,4 @@ class FirstTest(LiveServerTestCase):
         print 'teardown'
 
 if __name__ == '__main__':
-
-    server = Process(target=flaskapp.main)
-    server.start()
     unittest.main()

--- a/flaskapp/tests.py
+++ b/flaskapp/tests.py
@@ -7,8 +7,6 @@ import json
 import requests
 import flaskapp
 
-from multiprocessing import Process
-
 import time
 
 class FirstTest(LiveServerTestCase):
@@ -24,16 +22,6 @@ class FirstTest(LiveServerTestCase):
         print 'setup'
 
     ###This must be first
-    def test_shutdown_text_outputted(self):
-        url = self.get_server_url() + '/shutdown'
-        r = requests.post(url = url, data = {})
-        self.assertEqual(r.text, 'Server shutting down...')
-
-    def test_shutdown_error_outputted(self):
-        with self.assertRaises(RuntimeError):
-            r = flaskapp.shutdown()
-            print 'Errored as expected: '+r.text
-
     def test_server_is_up_and_running(self):
         url = self.get_server_url() + '/'
         response = urllib2.urlopen(self.get_server_url())

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ Flask==0.12.2
 Flask-Testing==0.7.1
 Jinja2==2.10
 MarkupSafe==1.0
-Werkzeug==0.14.1
 certifi==2018.01.18
 chardet==3.0.4
 click==6.7


### PR DESCRIPTION
This PR implements two main features:

- Uses the FlaskTesting server that is provisioned instead of the instance we were previously using to run tests (minor optimization)
- Removes the `/shutdown` route that is no longer necessary as we are not using the multithreaded server

Closes #13 