### PR TITLE
First pass at a method for QRverification

### DIFF
--- a/flaskapp/flaskapp.py
+++ b/flaskapp/flaskapp.py
@@ -94,6 +94,26 @@ def post():                                         # pragma: no cover
         return 'invalid request'
 
 
+@app.route('/lock', methods = ['GET', 'POST'])
+def lock():
+    #If 'POST' then write the new value
+    if(request.values):
+        lock = request.values.get('lock')
+
+        #Check value in correct range
+        if(lock in ['0','1']):
+            get_cache()['lock'] = lock
+        else:
+            return 'invalid value'
+
+    #Otherwise if 'GET' flip the value:
+    else:
+        get_cache()['lock'] = str(1 - int(get_cache()['lock']))
+
+    #Return the value
+    return get_cache()['lock']
+
+
 #Used if there is an error in the application.
 @app.errorhandler(Exception)
 def exception_handler(error):

--- a/flaskapp/tests.py
+++ b/flaskapp/tests.py
@@ -55,6 +55,23 @@ class FirstTest(LiveServerTestCase):
         ret = flaskapp.exception_handler("error")
         self.assertEqual(ret, "Oh no! 'error'")
 
+    def test_post_lock_works(self):
+        data = {'lock':1}
+        urlPost = self.get_server_url() + '/lock'
+        r = requests.post(url = urlPost, data = data)
+        retData = eval(str(r.text))
+        self.assertEqual(data['lock'], 1)
+        print 'Successfully returned: '+r.text
+
+    def test_get_lock_flips_value(self):
+        url = self.get_server_url() + '/lock'
+        r1 = requests.get(url = url)
+        valFirst = str(r1.text)
+        valExpectedNext = str(1 - int(valFirst)) # (1-0 = 1, 1-1=0)
+        r2 = requests.get(url = url)
+        self.assertEqual(str(r2.text), valExpectedNext)
+        print 'Successfully returned: '+r2.text
+
 
     #Object tests
     def test_pacakge_init(self):

--- a/flaskapp/tests.py
+++ b/flaskapp/tests.py
@@ -55,6 +55,24 @@ class FirstTest(LiveServerTestCase):
         ret = flaskapp.exception_handler("error")
         self.assertEqual(ret, "Oh no! 'error'")
 
+    def test_post_lock_works(self):
+        data = {'lock':1}
+        urlPost = self.get_server_url() + '/lock'
+        r = requests.post(url = urlPost, data = data)
+        retData = eval(str(r.text))
+        self.assertEqual(data['lock'], 1)
+        print 'Successfully returned: '+r.text
+
+    def test_get_lock_flips_value(self):
+        data = {'lock':1}
+        url = self.get_server_url() + '/lock'
+        r = requests.post(url = url, data = data)
+        valFirst = 1
+        valExpectedNext = str(1 - int(valFirst)) # (1-0 = 1, 1-1=0)
+        r2 = requests.get(url = url)
+        self.assertEqual(str(r2.text), valExpectedNext)
+        print 'Successfully returned: '+r2.text
+
 
     #Object tests
     def test_pacakge_init(self):


### PR DESCRIPTION
Adds a boolean 'locked' value. The idea is that scanning the QR code on the bot will flip this value. The ardunio/ev3 could then read that value and open the box accordingly. The logic definitely needs further refined and we'll want to do this in a more secure way by milestone 4 - this is more for proof of concept.

Link to ev3 PR: https://github.com/Team9-RobotIX/EV3/pull/1

(@zesme let me know if I'm using the branches incorrectly)