### PR TITLE
Milestone 2 API routes

### DIFF
--- a/flaskapp/classes.py
+++ b/flaskapp/classes.py
@@ -1,3 +1,6 @@
+from enum import Enum
+
+
 # Describes the item added to the delivery
 class Package:
     def __init__(self, id, name, description, priority, minTemp,
@@ -27,3 +30,43 @@ class Delivery:
         self.state = state
         if(len(packageList) < 1):
             raise ValueError("No packages")
+
+
+# Describes an instruction to the robot
+class InstructionType(Enum):
+    MOVE = 0,
+    TURN = 1
+
+
+class Instruction:
+    def __init__(self, type, value):
+        self.type = type
+        self.value = value
+
+        if(not isinstance(type, InstructionType)):
+            raise ValueError("Instruction type must be of type \
+                             InstructionType")
+        else:
+            if(type == InstructionType.TURN):
+                if(value < -180.0 or value > 180.0):
+                    raise ValueError("Turn angle must be between -180.0 \
+                                     and 180.0")
+
+    @classmethod
+    def from_dict(self, obj):
+        """
+        Takes in a dictionary (e.g.: instruction type as string) and returns
+        a valid Instruction instance.
+        """
+        type = None
+        value = None
+
+        if(obj['type'] == 'MOVE'):
+            type = InstructionType.MOVE
+        elif(obj['type'] == 'TURN'):
+            type = InstructionType.TURN
+        else:
+            raise ValueError("Invalid instruction type.")
+
+        value = float(obj['value'])
+        return Instruction(type, value)

--- a/flaskapp/classes.py
+++ b/flaskapp/classes.py
@@ -1,35 +1,36 @@
 from enum import Enum
 
 
-# Describes the item added to the delivery
-class Package:
-    def __init__(self, id, name, description, priority, minTemp,
-                 maxTemp, timeLimit):
+# A delivery contains packages
+class DeliveryState(Enum):
+    IN_QUEUE = 0,
+    IN_PROGRESS = 1,
+    AWAITING_AUTHENTICATION = 2,
+    AWAITING_PICKUP = 3,
+    COMPLETED = 4,
+    UNKNOWN = 5
+
+
+class Delivery:
+    def __init__(self, id, fromTarget, toTarget, priority, name, description = None,
+                 state = DeliveryState.UNKNOWN, minTemp = None,
+                 maxTemp = None, timeLimit = None):
         self.id = id
+        self.fromTarget = fromTarget
+        self.toTarget = toTarget
         self.name = name
         self.description = description
         self.priority = priority
+
+        self.state = state
         self.minTemp = minTemp
         self.maxTemp = maxTemp
         self.timeLimit = timeLimit
-        if(minTemp > maxTemp):
+
+        if(minTemp and maxTemp and minTemp > maxTemp):
             raise ValueError("Invalid temperatures")
-        if(timeLimit < 0):
+        if(timeLimit and timeLimit < 0):
             raise ValueError("Invalid time limit")
-
-
-# A delivery contains packages
-class Delivery:
-    def __init__(self, id, packageList, fromLoc, toLoc, state):
-        self.id = id
-        self.packageList = packageList
-        self.fromLoc = fromLoc
-        self.toLoc = toLoc
-        # Lowest number has highest priority
-        self.priority = min([x.priority for x in packageList])
-        self.state = state
-        if(len(packageList) < 1):
-            raise ValueError("No packages")
 
 
 # Describes an instruction to the robot

--- a/flaskapp/classes.py
+++ b/flaskapp/classes.py
@@ -1,6 +1,7 @@
-#Describes the item added to the delivery
+# Describes the item added to the delivery
 class Package:
-    def __init__(self, id, name, description, priority, minTemp, maxTemp, timeLimit):
+    def __init__(self, id, name, description, priority, minTemp,
+                 maxTemp, timeLimit):
         self.id = id
         self.name = name
         self.description = description
@@ -13,14 +14,16 @@ class Package:
         if(timeLimit < 0):
             raise ValueError("Invalid time limit")
 
-#A delivery contains packages
+
+# A delivery contains packages
 class Delivery:
     def __init__(self, id, packageList, fromLoc, toLoc, state):
         self.id = id
         self.packageList = packageList
         self.fromLoc = fromLoc
         self.toLoc = toLoc
-        self.priority = min([x.priority for x in packageList]) #lowest number highest priority
+        # Lowest number has highest priority
+        self.priority = min([x.priority for x in packageList])
         self.state = state
         if(len(packageList) < 1):
             raise ValueError("No packages")

--- a/flaskapp/classes.py
+++ b/flaskapp/classes.py
@@ -70,3 +70,44 @@ class Instruction:
 
         value = float(obj['value'])
         return Instruction(type, value)
+
+
+# Describes a possible target location
+class Target:
+    def __init__(self, id, name, description = None, color = None):
+        self.id = id
+        self.name = name
+        self.description = description
+        self.color = color
+
+        if(not isinstance(id, int)):
+            raise ValueError("ID must be positive integer")
+        elif(id < 0):
+            raise ValueError("ID must be positive integer")
+        elif(not isinstance(name, basestring)):         # NOQA
+            raise ValueError("Name must be string")
+        elif(description is not None and
+             not isinstance(description, basestring)):  # NOQA
+            raise ValueError("Description must be string")
+        elif(color is not None and
+             not isinstance(color, basestring)):        # NOQA
+            raise ValueError("Color must be string")
+
+    @classmethod
+    def from_dict(self, obj):
+        """
+        Takes in a dictionary (e.g.: from JSON request) and returns
+        a valid Target instance.
+        """
+        id = obj['id']
+        name = obj['name']
+        description = None
+        color = None
+
+        if 'description' in obj:
+            description = obj['description']
+
+        if 'color' in obj:
+            color = obj['color']
+
+        return Target(id, name, description, color)

--- a/flaskapp/classes.py
+++ b/flaskapp/classes.py
@@ -1,0 +1,26 @@
+#Describes the item added to the delivery
+class Package:
+    def __init__(self, id, name, description, priority, minTemp, maxTemp, timeLimit):
+        self.id = id
+        self.name = name
+        self.description = description
+        self.priority = priority
+        self.minTemp = minTemp
+        self.maxTemp = maxTemp
+        self.timeLimit = timeLimit
+        if(minTemp > maxTemp):
+            raise ValueError("Invalid temperatures")
+        if(timeLimit < 0):
+            raise ValueError("Invalid time limit")
+
+#A delivery contains packages
+class Delivery:
+    def __init__(self, id, packageList, fromLoc, toLoc, state):
+        self.id = id
+        self.packageList = packageList
+        self.fromLoc = fromLoc
+        self.toLoc = toLoc
+        self.priority = min([x.priority for x in packageList]) #lowest number highest priority
+        self.state = state
+        if(len(packageList) < 1):
+            raise ValueError("No packages")

--- a/flaskapp/encoder.py
+++ b/flaskapp/encoder.py
@@ -1,0 +1,12 @@
+from flask.json import JSONEncoder
+from classes import Instruction
+
+
+class CustomJSONEncoder(JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, Instruction):
+            return {
+                'type': obj.type.name,
+                'value': obj.value
+            }
+        return super(CustomJSONEncoder, self).default(obj)

--- a/flaskapp/encoder.py
+++ b/flaskapp/encoder.py
@@ -1,5 +1,5 @@
 from flask.json import JSONEncoder
-from classes import Instruction, Target
+from classes import Instruction, Target, Delivery
 
 
 class CustomJSONEncoder(JSONEncoder):
@@ -20,6 +20,19 @@ class CustomJSONEncoder(JSONEncoder):
 
             if obj.color is not None:
                 res['color'] = obj.color
+
+            return res
+        elif isinstance(obj, Delivery):
+            res = {
+                'id': obj.id,
+                'name': obj.name,
+                'priority': obj.priority,
+                'from': obj.fromTarget,
+                'to': obj.toTarget
+            }
+
+            if obj.description is not None:
+                res['description'] = obj.description
 
             return res
 

--- a/flaskapp/encoder.py
+++ b/flaskapp/encoder.py
@@ -1,5 +1,5 @@
 from flask.json import JSONEncoder
-from classes import Instruction
+from classes import Instruction, Target
 
 
 class CustomJSONEncoder(JSONEncoder):
@@ -9,4 +9,18 @@ class CustomJSONEncoder(JSONEncoder):
                 'type': obj.type.name,
                 'value': obj.value
             }
+        elif isinstance(obj, Target):
+            res = {
+                'id': obj.id,
+                'name': obj.name
+            }
+
+            if obj.description is not None:
+                res['description'] = obj.description
+
+            if obj.color is not None:
+                res['color'] = obj.color
+
+            return res
+
         return super(CustomJSONEncoder, self).default(obj)

--- a/flaskapp/encoder.py
+++ b/flaskapp/encoder.py
@@ -1,5 +1,5 @@
 from flask.json import JSONEncoder
-from classes import Instruction, Target, Delivery
+from classes import Instruction, Target, Delivery, DeliveryState
 
 
 class CustomJSONEncoder(JSONEncoder):
@@ -22,13 +22,16 @@ class CustomJSONEncoder(JSONEncoder):
                 res['color'] = obj.color
 
             return res
+        elif isinstance(obj, DeliveryState):
+            return obj.name
         elif isinstance(obj, Delivery):
             res = {
                 'id': obj.id,
                 'name': obj.name,
                 'priority': obj.priority,
                 'from': obj.fromTarget,
-                'to': obj.toTarget
+                'to': obj.toTarget,
+                'state': obj.state
             }
 
             if obj.description is not None:

--- a/flaskapp/flaskapp.py
+++ b/flaskapp/flaskapp.py
@@ -105,6 +105,68 @@ def queuePage():                                    # pragma: no cover
     return 'Queue: ' + str([x.name for x in d])
 
 
+#                                          #
+#              TARGET ROUTES               #
+#                                          #
+@app.route('/targets', methods = ['GET'])
+def targets_get():
+    targetsTable = get_db()['targets']
+    targets = targetsTable.all()
+
+    result = []
+    for t in targets:
+        obj = {
+            'id': t['id'],
+            'name': t['name']
+        }
+
+        if 'description' in t:
+            obj['description'] = t['description']
+
+        if 'color' in t:
+            obj['color'] = t['color']
+
+        result.append(obj)
+
+    return jsonify(result)
+
+
+@app.route('/targets', methods = ['POST'])
+def targets_post():
+    targetsTable = get_db()['targets']
+    data = request.get_json(force=True)
+
+    if 'name' not in data:
+        return bad_request("Must provide name for target.")
+    elif not isinstance(data['name'], basestring):  # NOQA
+        return bad_request("Name must be string")
+    elif 'description' in data and not isinstance(data['description'], basestring):  # NOQA
+        return bad_request("Description must be string")
+    elif 'color' in data and not isinstance(data['color'], str):
+        return bad_request("Color must be string")
+
+    obj = {
+        'name': data['name']
+    }
+
+    if 'description' in data:
+        obj['description'] = data['description']
+
+    if 'color' in data:
+        obj['color'] = data['color']
+
+    targetsTable.insert(obj)
+
+    return targets_get()
+
+
+@app.route('/targets', methods = ['DELETE'])
+def targets_delete():
+    targetsTable = get_db()['targets']
+    targetsTable.drop()
+    return ''
+
+
 #                                         #
 #              ROBOT ROUTES               #
 #                                         #

--- a/flaskapp/flaskapp.py
+++ b/flaskapp/flaskapp.py
@@ -142,6 +142,30 @@ def instructions_delete():
     return ''
 
 
+# Instruction routes
+@app.route('/instruction/<int:index>', methods = ['GET'])
+def instruction_get(index):
+    if 'instructions' not in get_cache():
+        return file_not_found("This instruction does not exist")
+    elif index >= len(get_cache()['instructions']) or index < 0:
+        return file_not_found("This instruction does not exist")
+
+    return jsonify(get_cache()['instructions'][index])
+
+
+@app.route('/instruction/<int:index>', methods = ['DELETE'])
+def instruction_delete(index):
+    if 'instructions' not in get_cache():
+        return file_not_found("This instruction does not exist")
+    elif index >= len(get_cache()['instructions']) or index < 0:
+        return file_not_found("This instruction does not exist")
+
+    get_cache()['instructions'] = (get_cache()['instructions'][:index] +
+                                   get_cache()['instructions'][index + 1:])
+
+    return ''
+
+
 # Correction routes
 @app.route('/correction', methods = ['GET'])
 def correction_get():

--- a/flaskapp/flaskapp.py
+++ b/flaskapp/flaskapp.py
@@ -4,6 +4,7 @@ import heapq
 import dataset
 import shelve
 from flask_bcrypt import Bcrypt
+from classes import Package, Delivery
 
 app = Flask(__name__)
 app.config.from_object('config.Config')
@@ -182,34 +183,6 @@ def exception_handler(error):
 @app.errorhandler(401)
 def custom_401(error):
     return 'Access denied', 401
-
-
-#Describes the item added to the delivery
-class Package:
-    def __init__(self, id, name, description, priority, minTemp, maxTemp, timeLimit):
-        self.id = id
-        self.name = name
-        self.description = description
-        self.priority = priority
-        self.minTemp = minTemp
-        self.maxTemp = maxTemp
-        self.timeLimit = timeLimit
-        if(minTemp > maxTemp):
-            raise ValueError("Invalid temperatures")
-        if(timeLimit < 0):
-            raise ValueError("Invalid time limit")
-
-#A delivery contains packages
-class Delivery:
-    def __init__(self, id, packageList, fromLoc, toLoc, state):
-        self.id = id
-        self.packageList = packageList
-        self.fromLoc = fromLoc
-        self.toLoc = toLoc
-        self.priority = min([x.priority for x in packageList]) #lowest number highest priority
-        self.state = state
-        if(len(packageList) < 1):
-            raise ValueError("No packages")
 
 
 def main():

--- a/flaskapp/flaskapp.py
+++ b/flaskapp/flaskapp.py
@@ -142,6 +142,33 @@ def instructions_delete():
     return ''
 
 
+# Batch instructions route
+@app.route('/instructions/batch', methods = ['GET'])
+def instructions_batch_get():
+    limit = request.values.get('limit')
+    if limit is None:
+        limit = len(get_cache()['instructions'])
+
+    try:
+        limit = int(limit)
+    except Exception as e:
+        return bad_request("Limit has to be positive integer")
+
+    if 'instructions' not in get_cache():
+        get_cache()['instructions'] = []
+    elif len(get_cache()['instructions']) > 0 and limit <= 0:
+        return bad_request("Limit has to be positive integer")
+
+    instructions = get_cache()['instructions'][:limit]
+
+    if 'correction' in get_cache():
+        correction = {'angle': get_cache()['correction']}
+        return jsonify({'instructions': instructions,
+                        'correction': correction})
+    else:
+        return jsonify({'instructions': instructions})
+
+
 # Instruction routes
 @app.route('/instruction/<int:index>', methods = ['GET'])
 def instruction_get(index):

--- a/flaskapp/flaskapp.py
+++ b/flaskapp/flaskapp.py
@@ -66,47 +66,6 @@ def register():
         return "invalid username/password"
 
 
-# Demo of adding to and removing from the queue
-"""
-@app.route('/getQueue', methods = ['GET', 'POST'])
-def queuePage():                                    # pragma: no cover
-    h = []
-
-    # Low priority delivery with 1 package
-    pList1 = []
-    p1 = Package(1, 'BloodSample', 'A sample of blood', 2, -5, 3, 3600)
-    pList1.append(p1)
-    d1 = Delivery(1, pList1, 'A', 'B', 'PENDING')
-
-    # Medium priority delivery with 1 package
-    pList2 = []
-    p2 = Package(2, 'Shoe', 'A shoe', 3, -5, 100, 100000)
-    pList2.append(p2)
-    d2 = Delivery(2, pList2, 'C', 'D', 'PENDING')
-
-    # High priority delivery with 2 packages
-    pList3 = []
-    p3 = Package(3, 'Heart', 'An actual human heart', 1, -5, 5, 600)
-    p4 = Package(4, 'Barack Obama',
-                 '44th President of the United States Barack Obama', 1,
-                 -5, 40, 600)
-    pList3.append(p3)
-    pList3.append(p4)
-    d3 = Delivery(3, pList3, 'B', 'D', 'PENDING')
-
-    # Push all deliveries onto the heap queue
-    heapq.heappush(h, (d1.priority, d1.packageList))
-    heapq.heappush(h, (d2.priority, d2.packageList))
-    heapq.heappush(h, (d3.priority, d3.packageList))
-
-    # Get the list of packages in the Delivery
-    d = heapq.heappop(h)[1]
-
-    # Return the names of every package in the delivery
-    return 'Queue: ' + str([x.name for x in d])
-"""
-
-
 #                                            #
 #              DELIVERY ROUTES               #
 #                                            #

--- a/flaskapp/flaskapp.py
+++ b/flaskapp/flaskapp.py
@@ -151,29 +151,6 @@ def post():                                         # pragma: no cover
         return 'invalid request'
 
 
-@app.route('/lock', methods = ['GET', 'POST'])
-def lock():
-    if 'lock' not in get_cache():
-        get_cache()['lock'] = 0
-
-    # If 'POST' then write the new value
-    if(request.values):
-        lock = request.values.get('lock')
-
-        # Check value in correct range
-        if(lock in ['0', '1']):
-            get_cache()['lock'] = lock
-        else:
-            return 'invalid value'
-
-    # Otherwise if 'GET' flip the value:
-    else:
-        get_cache()['lock'] = str(1 - int(get_cache()['lock']))
-
-    # Return the value
-    return get_cache()['lock']
-
-
 #                                         #
 #              ROBOT ROUTES               #
 #                                         #
@@ -211,6 +188,29 @@ def instructions_delete():
     return ''
 
 
+@app.route('/lock', methods = ['GET'])
+def lock_get():
+    if 'locked' not in get_cache():
+        get_cache()['locked'] = False
+
+    return jsonify({'locked': get_cache()['locked']})
+
+
+@app.route('/lock', methods = ['POST'])
+def lock_post():
+    data = request.get_json(force=True)
+
+    print(data)
+    if 'locked' not in data:
+        return bad_request("Must supply a state for the lock.")
+    elif not isinstance(data['locked'], bool):
+        return bad_request("Invalid lock state supplied.")
+
+    get_cache()['locked'] = data['locked']
+
+    return jsonify({'locked': get_cache()['locked']})
+
+
 # Used if there is an error in the application.
 def bad_request(friendly):
     error_code = 400
@@ -222,7 +222,7 @@ def bad_request(friendly):
         'friendly':  friendly
     }
 
-    return data, 400
+    return jsonify(data), 400
 
 
 @app.errorhandler(Exception)

--- a/flaskapp/flaskapp.py
+++ b/flaskapp/flaskapp.py
@@ -142,6 +142,40 @@ def instructions_delete():
     return ''
 
 
+# Correction routes
+@app.route('/correction', methods = ['GET'])
+def correction_get():
+    if 'correction' not in get_cache():
+        return file_not_found("No correction has been issued!")
+
+    return jsonify({'angle': get_cache()['correction']})
+
+
+@app.route('/correction', methods = ['POST'])
+def correction_post():
+    if 'correction' in get_cache():
+        return bad_request("A correction has already been issued!")
+
+    data = request.get_json(force=True)
+    if 'angle' not in data:
+        return bad_request("You have not supplied a correction angle!")
+    elif not isinstance(data['angle'], float):
+        return bad_request("Supplied angle is not a float")
+
+    get_cache()['correction'] = data['angle']
+    return jsonify({'angle': get_cache()['correction']})
+
+
+@app.route('/correction', methods = ['DELETE'])
+def correction_delete():
+    if 'correction' not in get_cache():
+        return file_not_found("No correction has been issued!")
+
+    del get_cache()['correction']
+    return ''
+
+
+# Lock routes
 @app.route('/lock', methods = ['GET'])
 def lock_get():
     if 'locked' not in get_cache():
@@ -176,7 +210,20 @@ def bad_request(friendly):
         'friendly':  friendly
     }
 
-    return jsonify(data), 400
+    return jsonify(data), error_code
+
+
+def file_not_found(friendly):
+    error_code = 404
+    error = 'File not found'
+
+    data = {
+        'code': error_code,
+        'error': error,
+        'friendly':  friendly
+    }
+
+    return jsonify(data), error_code
 
 
 @app.errorhandler(Exception)

--- a/flaskapp/flaskapp.py
+++ b/flaskapp/flaskapp.py
@@ -115,18 +115,7 @@ def targets_get():
 
     result = []
     for t in targets:
-        obj = {
-            'id': t['id'],
-            'name': t['name']
-        }
-
-        if 'description' in t:
-            obj['description'] = t['description']
-
-        if 'color' in t:
-            obj['color'] = t['color']
-
-        result.append(obj)
+        result.append(Target.from_dict(t))
 
     return jsonify(result)
 

--- a/flaskapp/flaskapp.py
+++ b/flaskapp/flaskapp.py
@@ -36,19 +36,6 @@ def close_cache(error):
 
 
 # Reads the stored values and outputs them.
-@app.route('/', methods = ['GET', 'POST'])
-def index():
-    if 'onOff' not in get_cache():
-        get_cache()['onOff'] = 0
-
-    if 'turnAngle' not in get_cache():
-        get_cache()['turnAngle'] = 0.0
-
-    onOff = get_cache()['onOff']
-    turnAngle = get_cache()['turnAngle']
-    return jsonify({'onOff': onOff, 'turnAngle': turnAngle})
-
-
 @app.route('/login', methods = ['GET', 'POST'])
 def login():
     username = request.values.get('username')
@@ -116,23 +103,6 @@ def queuePage():                                    # pragma: no cover
 
     # Return the names of every package in the delivery
     return 'Queue: ' + str([x.name for x in d])
-
-
-# Receives post request and stores input in store.txt.
-@app.route('/post', methods = ['GET', 'POST'])
-def post():                                         # pragma: no cover
-
-    # Get the expected params.
-    onOff = int(request.values.get('onOff'))
-    turnAngle = float(request.values.get('turnAngle'))
-
-    # Check params are in expected ranges.
-    if( (int(onOff) in [0, 1]) and (-180 <= float(turnAngle) <= 180) ):
-        get_cache()['onOff'] = onOff
-        get_cache()['turnAngle'] = turnAngle
-        return jsonify({'onOff': onOff, 'turnAngle': turnAngle})
-    else:
-        return 'invalid request'
 
 
 #                                         #

--- a/flaskapp/flaskapp.py
+++ b/flaskapp/flaskapp.py
@@ -1,5 +1,4 @@
 from flask import Flask, abort, request, jsonify, g
-import sys, os, json
 import heapq
 import dataset
 import shelve
@@ -33,7 +32,8 @@ def close_cache(error):
     if hasattr(g, 'cache'):
         g.cache.close()
 
-#Reads the stored values and outputs them.
+
+# Reads the stored values and outputs them.
 @app.route('/', methods = ['GET', 'POST'])
 def index():
     if 'onOff' not in get_cache():
@@ -51,15 +51,15 @@ def index():
 def login():
     username = request.values.get('username')
     password = request.values.get('password')
-    
+
     usersTable = get_db()['users']
     user = usersTable.find_one(username=username)
-    hashedPassword = bcrypt.generate_password_hash(password)
-  
+
     if(user):
-         if(bcrypt.check_password_hash(user['password'], password)):
-             return str(username)+" "+str(password)+" token: TOKEN_PLACEHOLDER"
-    
+        if(bcrypt.check_password_hash(user['password'], password)):
+            return (str(username) + " " + str(password) +
+                    " token: TOKEN_PLACEHOLDER")
+
     abort(401)
 
 
@@ -70,14 +70,12 @@ def register():
     hashedPassword = bcrypt.generate_password_hash(password)
 
     usersTable = get_db()['users']
-    #[debug] clears table
-    #usersTable.delete()
-    if(username and password and len(username) > 0 and len(password) > 0): 
+    if(username and password and len(username) > 0 and len(password) > 0):
         usersTable.insert(dict(username=username, password=hashedPassword))
-        return str(username)+" added"
+        return str(username) + " added"
     else:
         return "invalid username/password"
-    
+
 
 @app.route('/instructionsPost', methods = ['GET', 'POST'])
 def instructions():
@@ -87,63 +85,63 @@ def instructions():
     get_cache()['instructionValue'] = value
     return jsonify({'instruction': instruction, 'value': value})
 
+
 @app.route('/getInstruction', methods = ['GET', 'POST'])
 def getInstruction():
     instruction = get_cache()['instruction']
     value = get_cache()['instructionValue']
-    return "instruction : "+str(instruction)+" value: "+str(value)
+    return "instruction : " + str(instruction) + " value: " + str(value)
 
 
-#Demo of adding to and removing from the queue
+# Demo of adding to and removing from the queue
 @app.route('/getQueue', methods = ['GET', 'POST'])
-                                                    #Ignore from tests
 def queuePage():                                    # pragma: no cover
     h = []
 
-    #Low priority delivery with 1 package
+    # Low priority delivery with 1 package
     pList1 = []
     p1 = Package(1, 'BloodSample', 'A sample of blood', 2, -5, 3, 3600)
     pList1.append(p1)
     d1 = Delivery(1, pList1, 'A', 'B', 'PENDING')
 
-    #Medium priority delivery with 1 package
+    # Medium priority delivery with 1 package
     pList2 = []
     p2 = Package(2, 'Shoe', 'A shoe', 3, -5, 100, 100000)
     pList2.append(p2)
     d2 = Delivery(2, pList2, 'C', 'D', 'PENDING')
 
-    #High priority delivery with 2 packages
+    # High priority delivery with 2 packages
     pList3 = []
     p3 = Package(3, 'Heart', 'An actual human heart', 1, -5, 5, 600)
-    p4 = Package(4, 'Barack Obama', '44th President of the United States Barack Obama', 1, -5, 40, 600)
+    p4 = Package(4, 'Barack Obama',
+                 '44th President of the United States Barack Obama', 1,
+                 -5, 40, 600)
     pList3.append(p3)
     pList3.append(p4)
     d3 = Delivery(3, pList3, 'B', 'D', 'PENDING')
 
-    #Push all deliveries onto the heap queue
+    # Push all deliveries onto the heap queue
     heapq.heappush(h, (d1.priority, d1.packageList))
     heapq.heappush(h, (d2.priority, d2.packageList))
     heapq.heappush(h, (d3.priority, d3.packageList))
 
-    #Get the list of packages in the Delivery
+    # Get the list of packages in the Delivery
     d = heapq.heappop(h)[1]
 
-    #Return the names of every package in the delivery
+    # Return the names of every package in the delivery
     return 'Queue: ' + str([x.name for x in d])
 
 
-
-#Receives post request and stores input in store.txt.
+# Receives post request and stores input in store.txt.
 @app.route('/post', methods = ['GET', 'POST'])
-                                                    #Ignore from tests: already covered
 def post():                                         # pragma: no cover
 
-    #Get the expected params.
+    # Get the expected params.
     onOff = int(request.values.get('onOff'))
     turnAngle = float(request.values.get('turnAngle'))
 
-    #Check params are in expected ranges.
-    if( (int(onOff) in [0,1]) and (-180 <= float(turnAngle) <= 180) ):
+    # Check params are in expected ranges.
+    if( (int(onOff) in [0, 1]) and (-180 <= float(turnAngle) <= 180) ):
         get_cache()['onOff'] = onOff
         get_cache()['turnAngle'] = turnAngle
         return jsonify({'onOff': onOff, 'turnAngle': turnAngle})
@@ -156,25 +154,25 @@ def lock():
     if 'lock' not in get_cache():
         get_cache()['lock'] = 0
 
-    #If 'POST' then write the new value
+    # If 'POST' then write the new value
     if(request.values):
         lock = request.values.get('lock')
 
-        #Check value in correct range
-        if(lock in ['0','1']):
+        # Check value in correct range
+        if(lock in ['0', '1']):
             get_cache()['lock'] = lock
         else:
             return 'invalid value'
 
-    #Otherwise if 'GET' flip the value:
+    # Otherwise if 'GET' flip the value:
     else:
         get_cache()['lock'] = str(1 - int(get_cache()['lock']))
 
-    #Return the value
+    # Return the value
     return get_cache()['lock']
 
 
-#Used if there is an error in the application.
+# Used if there is an error in the application.
 @app.errorhandler(Exception)
 def exception_handler(error):
     return "Oh no! "  + repr(error), 400

--- a/flaskapp/flaskapp.py
+++ b/flaskapp/flaskapp.py
@@ -127,6 +127,7 @@ def deliveries_post():
         get_cache()['deliveryQueueCounter'] = 0
 
     data = request.get_json(force=True)
+    counter = get_cache()['deliveryQueueCounter']
 
     # Error checking
     if 'name' not in data:
@@ -151,15 +152,16 @@ def deliveries_post():
         return bad_request("To target doesn't exist")
 
     if 'description' in data:
-        d = Delivery(0, fromTarget, toTarget, data['priority'], data['name'],
-                     data['description'])
+        d = Delivery(counter, fromTarget, toTarget,
+                     data['priority'], data['name'], data['description'])
     else:
-        d = Delivery(0, fromTarget, toTarget, data['priority'], data['name'])
+        d = Delivery(counter, fromTarget, toTarget,
+                     data['priority'], data['name'])
 
     h = copy.deepcopy(get_cache()['deliveryQueue'])
-    get_cache()['deliveryQueueCounter'] += 1
-    heapq.heappush(h, [d.priority, get_cache()['deliveryQueueCounter'], d])
+    heapq.heappush(h, [d.priority, counter, d])
 
+    get_cache()['deliveryQueueCounter'] += 1
     get_cache()['deliveryQueue'] = h
 
     return deliveries_get()

--- a/flaskapp/flaskapp.py
+++ b/flaskapp/flaskapp.py
@@ -79,22 +79,6 @@ def register():
         return "invalid username/password"
 
 
-@app.route('/instructionsPost', methods = ['GET', 'POST'])
-def instructions():
-    instruction = request.values.get('instruction')
-    value = request.values.get('value')
-    get_cache()['instruction'] = instruction
-    get_cache()['instructionValue'] = value
-    return jsonify({'instruction': instruction, 'value': value})
-
-
-@app.route('/getInstruction', methods = ['GET', 'POST'])
-def getInstruction():
-    instruction = get_cache()['instruction']
-    value = get_cache()['instructionValue']
-    return "instruction : " + str(instruction) + " value: " + str(value)
-
-
 # Demo of adding to and removing from the queue
 @app.route('/getQueue', methods = ['GET', 'POST'])
 def queuePage():                                    # pragma: no cover

--- a/flaskapp/flaskapp.py
+++ b/flaskapp/flaskapp.py
@@ -4,7 +4,7 @@ import dataset
 import shelve
 import copy
 from flask_bcrypt import Bcrypt
-from classes import Delivery, Instruction, Target
+from classes import Delivery, Instruction, Target, DeliveryState
 from encoder import CustomJSONEncoder
 
 app = Flask(__name__)
@@ -171,7 +171,57 @@ def deliveries_post():
 def deliveries_delete():
     if 'deliveryQueue' in get_cache():
         get_cache()['deliveryQueue'] = []
+        get_cache()['deliveryQueueCounter'] = 0
 
+    return ''
+
+
+# Delivery route
+@app.route('/delivery/<int:id>', methods = ['GET'])
+def delivery_get(id):
+    if 'deliveryQueue' not in get_cache():
+        get_cache()['deliveryQueue'] = []
+
+    item = [x[2] for x in get_cache()['deliveryQueue'] if x[1] == id]
+    if len(item) <= 0:
+        return file_not_found("There's no delivery with that ID!")
+
+    return jsonify(item[0])
+
+
+@app.route('/delivery/<int:id>', methods = ['PATCH'])
+def delivery_patch(id):
+    if 'deliveryQueue' not in get_cache():
+        get_cache()['deliveryQueue'] = []
+
+    if 'deliveryQueue' not in get_cache():
+        get_cache()['deliveryQueue'] = []
+
+    item = [x[2] for x in get_cache()['deliveryQueue'] if x[1] == id]
+    if len(item) <= 0:
+        return file_not_found("There's no delivery with that ID!")
+
+    data = request.get_json(force=True)
+    if 'state' not in data:
+        return bad_request("Missing state")
+    if data['state'] not in [e.name for e in DeliveryState]:
+        return bad_request("Invalid state")
+
+    item[0].state = DeliveryState[data['state']]
+    return delivery_get(id)
+
+
+@app.route('/delivery/<int:id>', methods = ['DELETE'])
+def delivery_delete(id):
+    if 'deliveryQueue' not in get_cache():
+        get_cache()['deliveryQueue'] = []
+
+    item = [x[2] for x in get_cache()['deliveryQueue'] if x[1] == id]
+    if len(item) <= 0:
+        return file_not_found("There's no delivery with that ID!")
+
+    items = [x for x in get_cache()['deliveryQueue'] if x[1] != id]
+    get_cache()['deliveryQueue'] = items
     return ''
 
 

--- a/flaskapp/tests.py
+++ b/flaskapp/tests.py
@@ -235,6 +235,29 @@ class DeliveryGroupTest(TestCase):
         self.assertEquals(r.status_code, 200)
         self.assertEquals(r.json, [])
 
+    def test_post_deliveries_unique_id(self):
+        route = '/deliveries'
+        self.create_dummy_targets()
+        self.client.delete(route)
+
+        data = [{
+            'name': 'Blood sample',
+            'priority': 0,
+            'from': 1,
+            'to': 2
+        }, {
+            'name': 'Blood sample',
+            'priority': 0,
+            'from': 1,
+            'to': 2
+        }]
+        self.client.post(route, data = json.dumps(data[0]))
+        self.client.post(route, data = json.dumps(data[1]))
+
+        r = self.client.get(route)
+        self.assertEquals(r.status_code, 200)
+        self.assertNotEquals(r.json[0]['id'], r.json[1]['id'])
+
 
 class TargetGroupTest(TestCase):
     def create_app(self):

--- a/flaskapp/tests.py
+++ b/flaskapp/tests.py
@@ -105,6 +105,128 @@ class TargetGroupTest(TestCase):
         r = self.client.post(route, data = json.dumps(data[0]))
         self.assertEquals(r.status_code, 400)
 
+    # Target route
+    def test_get_target(self):
+        data = [{'name': 'ok', 'description': 'bar'},
+                {'name': 'Pharmacy', 'description': 'foo'}]
+        self.client.delete('/targets')
+        self.client.post('/targets', data = json.dumps(data[0]))
+        self.client.post('/targets', data = json.dumps(data[1]))
+
+        route = '/target/1'
+        r = self.client.get(route)
+        self.assertEquals(r.status_code, 200)
+        for k, v in data[0].iteritems():
+            self.assertEquals(v, r.json[k])
+
+        route = '/target/2'
+        r = self.client.get(route)
+        self.assertEquals(r.status_code, 200)
+        for k, v in data[1].iteritems():
+            self.assertEquals(v, r.json[k])
+
+    def test_get_target_error_invalid_index(self):
+        self.client.delete('/targets')
+
+        route = '/target/1'
+        r = self.client.get(route)
+        self.assertEquals(r.status_code, 404)
+
+        route = '/target/-1'
+        r = self.client.get(route)
+        self.assertEquals(r.status_code, 404)
+
+    def test_get_target_error_index_numeric(self):
+        self.client.delete('/targets')
+
+        route = '/target/a'
+        r = self.client.get(route)
+        self.assertEquals(r.status_code, 404)
+
+    def test_patch_target(self):
+        data = [{'name': 'ok', 'description': 'bar'},
+                {'name': 'Pharmacy', 'description': 'foo'}]
+        self.client.delete('/targets')
+        self.client.post('/targets', data = json.dumps(data[0]))
+
+        route = '/target/1'
+        data2 = {'color': 'red'}
+        r = self.client.patch(route, data = json.dumps(data2))
+        self.assertEquals(r.status_code, 200)
+        for k, v in data[1].iteritems():
+            self.assertEquals(v, data[1][k])
+        self.assertEquals(r.json['color'], 'red')
+
+    def test_patch_target_error_invalid_color(self):
+        data = [{'name': 'ok', 'description': 'bar'},
+                {'name': 'Pharmacy', 'description': 'foo'}]
+        self.client.delete('/targets')
+        self.client.post('/targets', data = json.dumps(data[0]))
+
+        route = '/target/1'
+        data2 = {'color': 2.0}
+        r = self.client.patch(route, data = json.dumps(data2))
+        self.assertEquals(r.status_code, 400)
+
+    def test_patch_target_error_invalid_index(self):
+        data = [{'name': 'ok', 'description': 'bar'},
+                {'name': 'Pharmacy', 'description': 'foo'}]
+        self.client.delete('/targets')
+        self.client.post('/targets', data = json.dumps(data[0]))
+
+        route = '/target/-1'
+        data2 = {'color': 'red'}
+        r = self.client.patch(route, data = json.dumps(data2))
+        self.assertEquals(r.status_code, 404)
+
+    def test_patch_target_error_index_numeric(self):
+        data = [{'name': 'ok', 'description': 'bar'},
+                {'name': 'Pharmacy', 'description': 'foo'}]
+        self.client.delete('/targets')
+        self.client.post('/targets', data = json.dumps(data[0]))
+
+        route = '/target/a'
+        data2 = {'color': 'red'}
+        r = self.client.patch(route, data = json.dumps(data2))
+        self.assertEquals(r.status_code, 404)
+
+    def test_delete_target(self):
+        data = [{'name': 'ok', 'description': 'bar'},
+                {'name': 'Pharmacy', 'description': 'foo'}]
+        self.client.delete('/targets')
+        self.client.post('/targets', data = json.dumps(data[0]))
+        self.client.post('/targets', data = json.dumps(data[1]))
+
+        route = '/target/1'
+        r = self.client.delete(route)
+        self.assertEquals(r.status_code, 200)
+
+    def test_delete_target_error_invalid_index(self):
+        data = [{'name': 'ok', 'description': 'bar'},
+                {'name': 'Pharmacy', 'description': 'foo'}]
+        self.client.delete('/targets')
+        self.client.post('/targets', data = json.dumps(data[0]))
+        self.client.post('/targets', data = json.dumps(data[1]))
+
+        route = '/target/3'
+        r = self.client.delete(route)
+        self.assertEquals(r.status_code, 404)
+
+        route = '/target/-1'
+        r = self.client.delete(route)
+        self.assertEquals(r.status_code, 404)
+
+    def test_delete_target_error_index_numeric(self):
+        data = [{'name': 'ok', 'description': 'bar'},
+                {'name': 'Pharmacy', 'description': 'foo'}]
+        self.client.delete('/targets')
+        self.client.post('/targets', data = json.dumps(data[0]))
+        self.client.post('/targets', data = json.dumps(data[1]))
+
+        route = '/target/a'
+        r = self.client.delete(route)
+        self.assertEquals(r.status_code, 404)
+
 
 class RobotGroupTest(TestCase):
     def create_app(self):

--- a/flaskapp/tests.py
+++ b/flaskapp/tests.py
@@ -2,6 +2,7 @@ from flask_testing import LiveServerTestCase
 import unittest
 import requests
 import flaskapp
+import simplejson
 
 
 class FirstTest(LiveServerTestCase):
@@ -79,6 +80,59 @@ class FirstTest(LiveServerTestCase):
         retData = eval(str(r.text))
         self.assertEquals(retData['onOff'], 0)
         self.assertEquals(retData['turnAngle'], 0.0)
+
+    #                           #
+    #       ROBOT ROUTES        #
+    #                           #
+
+    # Instruction routes
+    def test_delete_instructions(self):
+        url = self.get_server_url() + '/instructions'
+        r = requests.delete(url = url)
+        self.assertEquals(r.status_code, 200)
+
+    def test_get_instructions_queue_empty(self):
+        url = self.get_server_url() + '/instructions'
+        requests.delete(url = url)
+
+        r = requests.get(url = url)
+        self.assertEquals(r.status_code, 200)
+        retData = simplejson.loads(r.text)
+        self.assertEquals(retData, [])
+
+    def test_get_instructions(self):
+        url = self.get_server_url() + '/instructions'
+        requests.delete(url = url)
+
+        data = [{'instruction': 'MOVE', 'value': '100'},
+                {'instruction': 'TURN', 'value': '90'}]
+        requests.post(url = url, data = data)
+
+        r = requests.get(url = url)
+        self.assertEquals(r.status_code, 200)
+        retData = simplejson.loads(r.text)
+        self.assertEquals(retData, data)
+
+    def test_post_instructions_single(self):
+        url = self.get_server_url() + '/instructions'
+        requests.delete(url = url)
+
+        data = {'instruction': 'MOVE', 'value': '100'}
+        r = requests.post(url = url, data = data)
+        self.assertEquals(r.status_code, 200)
+        retData = simplejson.loads(r.text)
+        self.assertEquals(retData, [data])
+
+    def test_post_instructions_multiple(self):
+        url = self.get_server_url() + '/instructions'
+        requests.delete(url = url)
+
+        data = [{'instruction': 'MOVE', 'value': '100'},
+                {'instruction': 'TURN', 'value': '90'}]
+        r = requests.post(url = url, data = data)
+        self.assertEquals(r.status_code, 200)
+        retData = simplejson.loads(r.text)
+        self.assertEquals(retData, data)
 
     # Object tests
     def test_pacakge_init(self):

--- a/flaskapp/tests.py
+++ b/flaskapp/tests.py
@@ -1,64 +1,7 @@
-from flask_testing import TestCase, LiveServerTestCase
+from flask_testing import TestCase
 import json
 import unittest
-import requests
 import flaskapp
-
-
-class FirstTest(LiveServerTestCase):
-    def create_app(self):
-        app = flaskapp.app
-        app.config['TESTING'] = True
-        app.config['LIVESERVER_PORT'] = 0
-        app.config['LIVESERVER_TIMEOUT'] = 10
-        return app
-
-    def test_server_is_up_and_running(self):
-        route = '/'
-        url = self.get_server_url() + route
-        r = requests.get(url = url)
-        self.assertEquals(r.status_code, 200)
-        print('Server is up and running')
-
-    def test_post_vals_works_with_correct_vals(self):
-        data = {'onOff': 1, 'turnAngle': 41.0}
-        route = '/post'
-        url = self.get_server_url() + route
-        r = requests.post(url = url, data = data)
-        retData = eval(str(r.text))
-        self.assertEqual(data['turnAngle'], retData['turnAngle'])
-        self.assertEqual(data['onOff'], retData['onOff'])
-        print('Successfully returned: ' + r.text)
-
-    def test_post_vals_fails_with_invalid_turnangle(self):
-        data = {'onOff': 1, 'turnAngle': 181.0}
-        route = '/post'
-        url = self.get_server_url() + route
-        r = requests.post(url = url, data = data)
-        self.assertEqual('invalid request', r.text)
-        print('Failed as expected: ' + r.text)
-
-    def test_post_vals_fails_with_invalid_onoff(self):
-        data = {'onOff': 2, 'turnAngle': 41.0}
-        route = '/post'
-        url = self.get_server_url() + route
-        r = requests.post(url = url, data = data)
-        self.assertEqual('invalid request', r.text)
-        print('Failed as expected: ' + r.text)
-
-    def test_exception_handler(self):
-        ret = flaskapp.exception_handler("error")
-        self.assertEqual(ret, ("Oh no! 'error'", 400))
-
-    def test_get_default_value(self):
-        route = '/'
-        url = self.get_server_url() + route
-        r = requests.get(url = url)
-        print(r.text)
-        self.assertEquals(r.status_code, 200)
-        retData = eval(str(r.text))
-        self.assertEquals(retData['onOff'], 0)
-        self.assertEquals(retData['turnAngle'], 0.0)
 
 
 class RobotGroupTest(TestCase):

--- a/flaskapp/tests.py
+++ b/flaskapp/tests.py
@@ -4,6 +4,108 @@ import unittest
 import flaskapp
 
 
+class TargetGroupTest(TestCase):
+    def create_app(self):
+        app = flaskapp.app
+        app.config['TESTING'] = True
+        return app
+
+    # Targets route
+    def test_get_targets_empty(self):
+        route = '/targets'
+        self.client.delete(route)
+
+        r = self.client.get(route)
+        self.assertEquals(r.status_code, 200)
+        self.assertEquals(r.json, [])
+
+    def test_get_targets_single(self):
+        route = '/targets'
+        data = [{'name': 'Reception'}]
+        self.client.delete(route)
+        self.client.post(route, data = json.dumps(data[0]))
+
+        r = self.client.get(route)
+        self.assertEquals(r.status_code, 200)
+        for i in range(0, len(r.json)):
+            for k, v in data[i].iteritems():
+                # ID assigned by server, so we don't check it
+                if k != 'id':
+                    self.assertEquals(v, data[i][k])
+
+    def test_get_targets_multiple(self):
+        route = '/targets'
+        data = [{'name': 'Reception'},
+                {'name': 'Pharmacy', 'description': 'foo'}]
+        self.client.delete(route)
+        self.client.post(route, data = json.dumps(data[0]))
+        self.client.post(route, data = json.dumps(data[1]))
+
+        r = self.client.get(route)
+        self.assertEquals(r.status_code, 200)
+        for i in range(0, len(r.json)):
+            for k, v in data[i].iteritems():
+                # ID assigned by server, so we don't check it
+                if k != 'id':
+                    self.assertEquals(v, data[i][k])
+
+    def test_post_targets_name_and_color(self):
+        route = '/targets'
+        data = [{'name': 'Reception', 'color': 'red'}]
+        self.client.delete(route)
+        self.client.post(route, data = json.dumps(data[0]))
+
+        r = self.client.get(route)
+        self.assertEquals(r.status_code, 200)
+        for i in range(0, len(r.json)):
+            for k, v in data[i].itemitems():
+                # ID assigned by server, so we don't check it
+                if k != 'id':
+                    self.assertEquals(v, data[i][k])
+
+    def test_post_targets_name_and_description(self):
+        route = '/targets'
+        data = [{'name': 'Reception', 'description': 'foo'}]
+        self.client.delete(route)
+        self.client.post(route, data = json.dumps(data[0]))
+
+        r = self.client.get(route)
+        self.assertEquals(r.status_code, 200)
+        for i in range(0, len(r.json)):
+            for k, v in data[i].iteritems():
+                # ID assigned by server, so we don't check it
+                if k != 'id':
+                    self.assertEquals(v, data[i][k])
+
+    def test_post_targets_error_name(self):
+        route = '/targets'
+        data = [{'name': 7}]
+        self.client.delete(route)
+        r = self.client.post(route, data = json.dumps(data[0]))
+        self.assertEquals(r.status_code, 400)
+
+    def test_post_targets_error_no_name(self):
+        route = '/targets'
+        data = [{'description': 'foo'}]
+        self.client.delete(route)
+        r = self.client.post(route, data = json.dumps(data[0]))
+        self.assertEquals(r.status_code, 400)
+
+    def test_post_targets_error_description(self):
+        route = '/targets'
+        data = [{'name': 'ok', 'description': 5}]
+        self.client.delete(route)
+        r = self.client.post(route, data = json.dumps(data[0]))
+        self.assertEquals(r.status_code, 400)
+
+    def test_post_targets_error_color(self):
+        route = '/targets'
+        data = [{'name': 'ok', 'description': 'foo', 'color': 4}]
+        self.client.delete(route)
+        r = self.client.post(route, data = json.dumps(data[0]))
+        self.assertEquals(r.status_code, 400)
+
+
 class RobotGroupTest(TestCase):
     def create_app(self):
         app = flaskapp.app

--- a/flaskapp/tests.py
+++ b/flaskapp/tests.py
@@ -87,6 +87,69 @@ class RobotGroupTest(TestCase):
         r = self.client.post(route, data = json.dumps(data))
         self.assertEquals(r.status_code, 400)
 
+    # Instruction routes
+    def test_get_instruction(self):
+        data = [{'type': 'MOVE', 'value': 100},
+                {'type': 'TURN', 'value': 90},
+                {'type': 'TURN', 'value': -90}]
+        self.client.delete('/instructions')
+        self.client.post('/instructions', data = json.dumps(data))
+
+        for i in range(0, 3):
+            route = '/instruction/' + str(i)
+            r = self.client.get(route)
+            self.assertEquals(r.status_code, 200)
+            self.assertEquals(r.json, data[i])
+
+    def test_get_instruction_invalid_index(self):
+        data = [{'type': 'MOVE', 'value': 100},
+                {'type': 'TURN', 'value': 90},
+                {'type': 'TURN', 'value': -90}]
+        self.client.delete('/instructions')
+        self.client.post('/instructions', data = json.dumps(data))
+
+        route = '/instruction/-1'
+        r = self.client.get(route)
+        self.assertEquals(r.status_code, 404)
+
+        route = '/instruction/4'
+        r = self.client.get(route)
+        self.assertEquals(r.status_code, 404)
+
+    def test_delete_instruction(self):
+        data = [{'type': 'MOVE', 'value': 100},
+                {'type': 'TURN', 'value': 90},
+                {'type': 'TURN', 'value': -90}]
+        self.client.delete('/instructions')
+        self.client.post('/instructions', data = json.dumps(data))
+
+        route = '/instruction/0'
+        r = self.client.delete(route)
+        self.assertEquals(r.status_code, 200)
+        s = self.client.get('/instructions')
+        self.assertEquals(s.status_code, 200)
+        self.assertEquals(s.json, [data[1], data[2]])
+
+    def test_delete_instruction_invalid_index(self):
+        data = [{'type': 'MOVE', 'value': 100},
+                {'type': 'TURN', 'value': 90},
+                {'type': 'TURN', 'value': -90}]
+        self.client.delete('/instructions')
+        self.client.post('/instructions', data = json.dumps(data))
+
+        route = '/instruction/-1'
+        r = self.client.delete(route)
+        self.assertEquals(r.status_code, 404)
+
+        route = '/instruction/4'
+        r = self.client.delete(route)
+        self.assertEquals(r.status_code, 404)
+
+        # Verify collection has not mutated
+        s = self.client.get('/instructions')
+        self.assertEquals(s.status_code, 200)
+        self.assertEquals(s.json, data)
+
     # Correction routes
     def test_get_correction_none(self):
         route = '/correction'

--- a/flaskapp/tests.py
+++ b/flaskapp/tests.py
@@ -87,6 +87,82 @@ class RobotGroupTest(TestCase):
         r = self.client.post(route, data = json.dumps(data))
         self.assertEquals(r.status_code, 400)
 
+    # Batch instructions route
+    def test_get_instruction_batch(self):
+        data = [{'type': 'MOVE', 'value': 100},
+                {'type': 'TURN', 'value': 90},
+                {'type': 'TURN', 'value': -90}]
+        data_correction = {'angle': 10.3}
+        self.client.delete('/instructions')
+        self.client.delete('/correction')
+        self.client.post('/instructions', data = json.dumps(data))
+        self.client.post('/correction', data = json.dumps(data_correction))
+
+        route = '/instructions/batch'
+        r = self.client.get(route)
+        self.assertEquals(r.status_code, 200)
+        self.assertEquals(r.json, {'instructions': data,
+                                   'correction': data_correction})
+
+    def test_get_instruction_batch_no_correction(self):
+        data = [{'type': 'MOVE', 'value': 100},
+                {'type': 'TURN', 'value': 90},
+                {'type': 'TURN', 'value': -90}]
+        self.client.delete('/instructions')
+        self.client.delete('/correction')
+        self.client.post('/instructions', data = json.dumps(data))
+
+        route = '/instructions/batch'
+        r = self.client.get(route)
+        self.assertEquals(r.status_code, 200)
+        self.assertEquals(r.json, {'instructions': data})
+
+    def test_get_instruction_batch_limit(self):
+        data = [{'type': 'MOVE', 'value': 100},
+                {'type': 'TURN', 'value': 90},
+                {'type': 'TURN', 'value': -90}]
+        data_correction = {'angle': 10.3}
+        self.client.delete('/instructions')
+        self.client.delete('/correction')
+        self.client.post('/instructions', data = json.dumps(data))
+        self.client.post('/correction', data = json.dumps(data_correction))
+
+        route = '/instructions/batch?limit=2'
+        r = self.client.get(route)
+        self.assertEquals(r.status_code, 200)
+        self.assertEquals(r.json, {'instructions': data[0:2],
+                                   'correction': data_correction})
+
+        route = '/instructions/batch?limit=3'
+        r = self.client.get(route)
+        self.assertEquals(r.status_code, 200)
+        self.assertEquals(r.json, {'instructions': data,
+                                   'correction': data_correction})
+
+        route = '/instructions/batch?limit=10'
+        r = self.client.get(route)
+        self.assertEquals(r.status_code, 200)
+        self.assertEquals(r.json, {'instructions': data,
+                                   'correction': data_correction})
+
+    def test_get_instruction_batch_limit_invalid(self):
+        data = [{'type': 'MOVE', 'value': 100},
+                {'type': 'TURN', 'value': 90},
+                {'type': 'TURN', 'value': -90}]
+        data_correction = {'angle': 10.3}
+        self.client.delete('/instructions')
+        self.client.delete('/correction')
+        self.client.post('/instructions', data = json.dumps(data))
+        self.client.post('/correction', data = json.dumps(data_correction))
+
+        route = '/instructions/batch?limit=0'
+        r = self.client.get(route)
+        self.assertEquals(r.status_code, 400)
+
+        route = '/instructions/batch?limit=-10'
+        r = self.client.get(route)
+        self.assertEquals(r.status_code, 400)
+
     # Instruction routes
     def test_get_instruction(self):
         data = [{'type': 'MOVE', 'value': 100},

--- a/flaskapp/tests.py
+++ b/flaskapp/tests.py
@@ -104,9 +104,9 @@ class FirstTest(LiveServerTestCase):
         url = self.get_server_url() + '/instructions'
         requests.delete(url = url)
 
-        data = [{'instruction': 'MOVE', 'value': '100'},
-                {'instruction': 'TURN', 'value': '90'}]
-        requests.post(url = url, data = data)
+        data = [{'type': 'MOVE', 'value': 100},
+                {'type': 'TURN', 'value': 90}]
+        requests.post(url = url, json = data)
 
         r = requests.get(url = url)
         self.assertEquals(r.status_code, 200)
@@ -117,8 +117,8 @@ class FirstTest(LiveServerTestCase):
         url = self.get_server_url() + '/instructions'
         requests.delete(url = url)
 
-        data = {'instruction': 'MOVE', 'value': '100'}
-        r = requests.post(url = url, data = data)
+        data = {'type': 'MOVE', 'value': 100}
+        r = requests.post(url = url, json = data)
         self.assertEquals(r.status_code, 200)
         retData = simplejson.loads(r.text)
         self.assertEquals(retData, [data])
@@ -127,12 +127,44 @@ class FirstTest(LiveServerTestCase):
         url = self.get_server_url() + '/instructions'
         requests.delete(url = url)
 
-        data = [{'instruction': 'MOVE', 'value': '100'},
-                {'instruction': 'TURN', 'value': '90'}]
-        r = requests.post(url = url, data = data)
+        data = [{'type': 'MOVE', 'value': 100},
+                {'type': 'TURN', 'value': 90}]
+        r = requests.post(url = url, json = data)
         self.assertEquals(r.status_code, 200)
         retData = simplejson.loads(r.text)
         self.assertEquals(retData, data)
+
+    def test_post_instructions_fails_with_missing_type(self):
+        url = self.get_server_url() + '/instructions'
+        requests.delete(url = url)
+
+        data = [{'value': 100}]
+        r = requests.post(url = url, json = data)
+        self.assertEquals(r.status_code, 400)
+
+    def test_post_instructions_fails_with_missing_value(self):
+        url = self.get_server_url() + '/instructions'
+        requests.delete(url = url)
+
+        data = [{'type': 'MOVE'}]
+        r = requests.post(url = url, json = data)
+        self.assertEquals(r.status_code, 400)
+
+    def test_post_instructions_fails_with_invalid_type(self):
+        url = self.get_server_url() + '/instructions'
+        requests.delete(url = url)
+
+        data = [{'type': 'HALT', 'value': 100}]
+        r = requests.post(url = url, json = data)
+        self.assertEquals(r.status_code, 400)
+
+    def test_post_instructions_fails_with_bad_angle(self):
+        url = self.get_server_url() + '/instructions'
+        requests.delete(url = url)
+
+        data = [{'type': 'TURN', 'value': 190.0}]
+        r = requests.post(url = url, json = data)
+        self.assertEquals(r.status_code, 400)
 
     # Object tests
     def test_pacakge_init(self):

--- a/flaskapp/tests.py
+++ b/flaskapp/tests.py
@@ -49,29 +49,6 @@ class FirstTest(LiveServerTestCase):
         ret = flaskapp.exception_handler("error")
         self.assertEqual(ret, ("Oh no! 'error'", 400))
 
-    def test_post_lock_works(self):
-        data = {'lock': 1}
-        urlPost = self.get_server_url() + '/lock'
-        r = requests.post(url = urlPost, data = data)
-        self.assertEqual(data['lock'], 1)
-        print('Successfully returned: ' + r.text)
-
-    def test_get_lock_flips_value(self):
-        data = {'lock': 1}
-        url = self.get_server_url() + '/lock'
-        requests.post(url = url, data = data)
-        valFirst = 1
-        valExpectedNext = str(1 - int(valFirst))  # (1-0 = 1, 1-1=0)
-        r2 = requests.get(url = url)
-        self.assertEqual(str(r2.text), valExpectedNext)
-        print('Successfully returned: ' + r2.text)
-
-    def test_get_lock_default_value(self):
-        url = self.get_server_url() + '/lock'
-        r = requests.post(url = url)
-        self.assertEquals(r.status_code, 200)
-        self.assertEquals(r.text, '1')
-
     def test_get_default_value(self):
         url = self.get_server_url() + '/'
         r = requests.get(url = url)
@@ -165,6 +142,43 @@ class FirstTest(LiveServerTestCase):
         data = [{'type': 'TURN', 'value': 190.0}]
         r = requests.post(url = url, json = data)
         self.assertEquals(r.status_code, 400)
+
+    # Lock routes
+    def test_post_lock_set_true(self):
+        data = {'locked': True}
+        url = self.get_server_url() + '/lock'
+        r = requests.post(url = url, json = data)
+        self.assertEquals(r.status_code, 200)
+        retData = simplejson.loads(r.text)
+        self.assertEquals(retData, data)
+
+    def test_post_lock_set_false(self):
+        data = {'locked': True}
+        url = self.get_server_url() + '/lock'
+        r = requests.post(url = url, json = data)
+        self.assertEquals(r.status_code, 200)
+        retData = simplejson.loads(r.text)
+        self.assertEquals(retData, data)
+
+    def test_get_lock_false(self):
+        url = self.get_server_url() + '/lock'
+        data = {'locked': False}
+        requests.post(url = url, json = data)
+
+        r = requests.get(url = url)
+        self.assertEquals(r.status_code, 200)
+        retData = simplejson.loads(r.text)
+        self.assertEquals(retData, data)
+
+    def test_get_lock_true(self):
+        url = self.get_server_url() + '/lock'
+        data = {'locked': True}
+        requests.post(url = url, json = data)
+
+        r = requests.get(url = url)
+        self.assertEquals(r.status_code, 200)
+        retData = simplejson.loads(r.text)
+        self.assertEquals(retData, data)
 
     # Object tests
     def test_pacakge_init(self):

--- a/flaskapp/tests.py
+++ b/flaskapp/tests.py
@@ -1,16 +1,10 @@
-import os
 from flask_testing import LiveServerTestCase
 import unittest
-import urllib2
-from flask import Flask
-import json
 import requests
 import flaskapp
 
-import time
 
 class FirstTest(LiveServerTestCase):
-    #Initialise testing app
     def create_app(self):
         app = flaskapp.app
         app.config['TESTING'] = True
@@ -19,59 +13,57 @@ class FirstTest(LiveServerTestCase):
         return app
 
     def setUp(self):
-        print 'setup'
+        print('setup')
 
-    ###This must be first
     def test_server_is_up_and_running(self):
         url = self.get_server_url() + '/'
         r = requests.get(url = url)
         self.assertEquals(r.status_code, 200)
-        print 'Server is up and running'
+        print('Server is up and running')
 
     def test_post_vals_works_with_correct_vals(self):
-        data = {'onOff':1, 'turnAngle':41.0}
+        data = {'onOff': 1, 'turnAngle': 41.0}
         url = self.get_server_url() + '/post'
         r = requests.post(url = url, data = data)
         retData = eval(str(r.text))
         self.assertEqual(data['turnAngle'], retData['turnAngle'])
         self.assertEqual(data['onOff'], retData['onOff'])
-        print 'Successfully returned: '+r.text
+        print('Successfully returned: ' + r.text)
 
     def test_post_vals_fails_with_invalid_turnangle(self):
-        data = {'onOff':1, 'turnAngle':181.0}
+        data = {'onOff': 1, 'turnAngle': 181.0}
         url = self.get_server_url() + '/post'
         r = requests.post(url = url, data = data)
         self.assertEqual('invalid request', r.text)
-        print 'Failed as expected: '+r.text
+        print('Failed as expected: ' + r.text)
 
     def test_post_vals_fails_with_invalid_onoff(self):
-        data = {'onOff':2, 'turnAngle':41.0}
+        data = {'onOff': 2, 'turnAngle': 41.0}
         url = self.get_server_url() + '/post'
         r = requests.post(url = url, data = data)
         self.assertEqual('invalid request', r.text)
-        print 'Failed as expected: '+r.text
+        print('Failed as expected: ' + r.text)
 
     def test_exception_handler(self):
         ret = flaskapp.exception_handler("error")
         self.assertEqual(ret, ("Oh no! 'error'", 400))
 
     def test_post_lock_works(self):
-        data = {'lock':1}
+        data = {'lock': 1}
         urlPost = self.get_server_url() + '/lock'
         r = requests.post(url = urlPost, data = data)
-        retData = eval(str(r.text))
         self.assertEqual(data['lock'], 1)
-        print 'Successfully returned: '+r.text
+        print('Successfully returned: ' + r.text)
 
     def test_get_lock_flips_value(self):
-        data = {'lock':1}
+        data = {'lock': 1}
         url = self.get_server_url() + '/lock'
-        r = requests.post(url = url, data = data)
+        requests.post(url = url, data = data)
         valFirst = 1
-        valExpectedNext = str(1 - int(valFirst)) # (1-0 = 1, 1-1=0)
+        valExpectedNext = str(1 - int(valFirst))  # (1-0 = 1, 1-1=0)
         r2 = requests.get(url = url)
         self.assertEqual(str(r2.text), valExpectedNext)
-        print 'Successfully returned: '+r2.text
+        print('Successfully returned: ' + r2.text)
 
     def test_get_lock_default_value(self):
         url = self.get_server_url() + '/lock'
@@ -82,49 +74,46 @@ class FirstTest(LiveServerTestCase):
     def test_get_default_value(self):
         url = self.get_server_url() + '/'
         r = requests.get(url = url)
-        print r.text
+        print(r.text)
         self.assertEquals(r.status_code, 200)
         retData = eval(str(r.text))
         self.assertEquals(retData['onOff'], 0)
         self.assertEquals(retData['turnAngle'], 0.0)
 
-
-
-    #Object tests
+    # Object tests
     def test_pacakge_init(self):
+        # Package can be initialised without errors
+        flaskapp.Package(1, 'package', 'desc', 3, 1, 5, 3600)
 
-        #Package can be initialised without errors
-        p1 = flaskapp.Package(1, 'package', 'desc', 3, 1, 5, 3600)
-
-        #Package wuth minTemp higher than maxTemp raises error
+        # Package wuth minTemp higher than maxTemp raises error
         with self.assertRaises(ValueError):
-            p2 = flaskapp.Package(2, 'package', 'desc', 3, 100, 0, 3600)
+            flaskapp.Package(2, 'package', 'desc', 3, 100, 0, 3600)
 
-        #Package with negative time raises error
+        # Package with negative time raises error
         with self.assertRaises(ValueError):
-            p3 = flaskapp.Package(3, 'package', 'desc', 3, 1, 5, -1)
+            flaskapp.Package(3, 'package', 'desc', 3, 1, 5, -1)
 
     def test_delivery_init(self):
         p1 = flaskapp.Package(1, 'package', 'desc', 3, 1, 5, 3600)
         pList = [p1]
 
-        #Delivery can be initialised without errors
-        d1 = flaskapp.Delivery(1, pList, 'A', 'B', 'PENDING')
+        # Delivery can be initialised without errors
+        flaskapp.Delivery(1, pList, 'A', 'B', 'PENDING')
 
-        #Delivery with no packages raises an error
+        # Delivery with no packages raises an error
         with self.assertRaises(ValueError):
-            d2 = flaskapp.Delivery(2, [], 'A', 'B', 'PENDING')
+            flaskapp.Delivery(2, [], 'A', 'B', 'PENDING')
 
         p2 = flaskapp.Package(2, 'package', 'desc', 1, 1, 5, 3600)
         pList.append(p2)
         d3 = flaskapp.Delivery(3, pList, 'A', 'B', 'PENDING')
 
-        #p1 has priority 3, p2 has priority 1 so delivery priority is 1.
+        # p1 has priority 3, p2 has priority 1 so delivery priority is 1.
         self.assertEqual(d3.priority, 1)
 
-
     def tearDown(self):
-        print 'teardown'
+        print('teardown')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/flaskapp/tests.py
+++ b/flaskapp/tests.py
@@ -87,6 +87,71 @@ class RobotGroupTest(TestCase):
         r = self.client.post(route, data = json.dumps(data))
         self.assertEquals(r.status_code, 400)
 
+    # Correction routes
+    def test_get_correction_none(self):
+        route = '/correction'
+        self.client.delete(route)
+
+        r = self.client.get(route)
+        self.assertEquals(r.status_code, 404)
+
+    def test_get_correction_angle(self):
+        route = '/correction'
+        data = {'angle': 50.0}
+        self.client.delete(route)
+        self.client.post(route, data = json.dumps(data))
+
+        r = self.client.get(route)
+        self.assertEquals(r.status_code, 200)
+
+    def test_post_correction_angle(self):
+        route = '/correction'
+        data = {'angle': 50.0}
+        self.client.delete(route)
+        r = self.client.post(route, data = json.dumps(data))
+        self.assertEquals(r.status_code, 200)
+        self.assertEquals(r.json, data)
+
+    def test_post_correction_error_resubmit(self):
+        route = '/correction'
+        data = {'angle': 50.0}
+
+        # Ensure a correction has already been issued
+        self.client.post(route, data = json.dumps(data))
+
+        r = self.client.post(route, data = json.dumps(data))
+        self.assertEquals(r.status_code, 400)
+
+    def test_post_correction_error_no_angle(self):
+        route = '/correction'
+        self.client.delete(route)
+
+        data = {'foo': 50.0}
+        r = self.client.post(route, data = json.dumps(data))
+        self.assertEquals(r.status_code, 400)
+
+    def test_post_correction_error_angle_not_float(self):
+        route = '/correction'
+        self.client.delete(route)
+
+        data = {'angle': 50}
+        r = self.client.post(route, data = json.dumps(data))
+        self.assertEquals(r.status_code, 400)
+
+    def test_delete_correction_angle(self):
+        route = '/correction'
+        data = {'angle': 50.0}
+        self.client.post(route, data = json.dumps(data))
+
+        r = self.client.delete(route)
+        self.assertEquals(r.status_code, 200)
+
+    def test_delete_correction_error(self):
+        route = '/correction'
+        self.client.delete(route)  # Ensure correction is clear
+        r = self.client.delete(route)
+        self.assertEquals(r.status_code, 404)
+
     # Lock routes
     def test_post_lock_set_true(self):
         data = {'locked': True}

--- a/flaskapp/tests.py
+++ b/flaskapp/tests.py
@@ -226,6 +226,7 @@ class DeliveryGroupTest(TestCase):
             'to': 2
         }]
         self.client.post(route, data = json.dumps(data[0]))
+        self.client.post(route, data = json.dumps(data[1]))
 
         r = self.client.delete(route)
         self.assertEquals(r.status_code, 200)

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ wsgiref==0.1.2
 dataset==1.0.5
 Flask-Bcrypt==0.7.1
 simplejson==3.13.2
+enum34==1.1.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ urllib3==1.22
 wsgiref==0.1.2
 dataset==1.0.5
 Flask-Bcrypt==0.7.1
+simplejson==3.13.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,4 @@ urllib3==1.22
 wsgiref==0.1.2
 dataset==1.0.5
 Flask-Bcrypt==0.7.1
-simplejson==3.13.2
 enum34==1.1.6


### PR DESCRIPTION
This PR includes the new API routes in preparation for Milestone 2.

Handles #26, #27 and possibly #31.

## New/updated routes:
- [x] /deliveries
- [x] /delivery/{id}
- [x] /targets
- [x] /target/{id}
- [x] /instructions
- [x] /instructions/batch
- [x] /instruction/{id}
- [x] /correction
- [x] /lock

## Other updates
- [x] Improve coverage (#30)